### PR TITLE
Updated repository name and links in package.json, updated license to MIT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "migration-prep-tool",
+  "name": "gh-migration-analyzer",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "migration-prep-tool",
+      "name": "gh-migration-analyzer",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -17,7 +17,7 @@
         "prompts": "^2.4.2"
       },
       "bin": {
-        "migration-prep-tool": "bin/migration-prep-tool"
+        "gh-migration-analyzer": "bin/gh-migration-analyzer"
       },
       "devDependencies": {
         "jest": "^27.3.1"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "migration-prep-tool",
+  "name": "gh-migration-analyzer",
   "version": "1.0.0",
   "description": "A command-line (cli) utility tool to help customers migrating repositories to GitHub plan for and size their migration.",
   "main": "src/commands/commands.js",
   "preferGlobal": true,
-  "bin": "bin/migration-prep-tool",
+  "bin": "bin/gh-migration-analyzer",
   "type": "module",
   "directories": {
     "doc": "docs"


### PR DESCRIPTION
This PR provides some clean up to package.json as we transition to an open-source project by including the paths to the public repository. I've also updated the license to MIT. 