### PR TITLE
Update required PAT scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Use the command ```cd <pathname of desired parent directory> && git clone https:
 You will need to generate a Personal Access Token (PAT) within your source (Azure DevOps or GitHub). The following scopes are required:
 
 * For Azure DevOps: `read` for `Code`.
-* For GitHub Cloud: `repo:status`.  
+* For GitHub Cloud: `repo`.  
 ## Dependencies
 
 Use the command ```cd <pathname of migration analyzer directory> && npm install``` to change to your ```migration-analyzer``` directory.  This will install the following project dependencies:


### PR DESCRIPTION
It looks like full 'repo' scope is needed to run the analyzer against a GitHub org. A lot of customers reported all 0s on issues and PRs when using only `repo:status`. 