### PR TITLE
Fix ReferenceError from invalid function parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,10 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "gh-migration-analyzer",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "commander": "^8.2.0",
+        "commander": "^8.3.0",
         "csv-writer": "^1.6.0",
         "node-fetch": "^2.6.0",
         "ora": "^6.0.1",
@@ -1506,9 +1505,9 @@
       }
     },
     "node_modules/commander": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.2.0.tgz",
-      "integrity": "sha512-LLKxDvHeL91/8MIyTAD5BFMNtoIwztGPMiM/7Bl8rIPmHCZXRxmSWr91h57dpOpnQ6jIUqEWdXE/uBYMfiVZDA==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "engines": {
         "node": ">= 12"
       }
@@ -5408,9 +5407,9 @@
       }
     },
     "commander": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.2.0.tgz",
-      "integrity": "sha512-LLKxDvHeL91/8MIyTAD5BFMNtoIwztGPMiM/7Bl8rIPmHCZXRxmSWr91h57dpOpnQ6jIUqEWdXE/uBYMfiVZDA=="
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
     },
     "concat-map": {
       "version": "0.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "commander": "^8.3.0",
         "csv-writer": "^1.6.0",
+        "minimist": "^1.2.6",
         "node-fetch": "^2.6.0",
         "ora": "^6.0.1",
         "p-limit": "^4.0.0",
@@ -3193,10 +3194,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -6678,10 +6678,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/github/gh-migration-analyzer#readme",
   "dependencies": {
-    "commander": "^8.2.0",
+    "commander": "^8.3.0",
     "csv-writer": "^1.6.0",
     "node-fetch": "^2.6.0",
     "ora": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "commander": "^8.3.0",
     "csv-writer": "^1.6.0",
+    "minimist": "^1.2.6",
     "node-fetch": "^2.6.0",
     "ora": "^6.0.1",
     "p-limit": "^4.0.0",

--- a/src/api/gitHub.js
+++ b/src/api/gitHub.js
@@ -90,7 +90,7 @@ export const fetchRepoInOrg = async (org, token, server, cursor) => {
       return res.json();
     })
     .catch((err) => {
-      handleStatusError(500);
+      handleStatusError(500, err);
     });
 };
 

--- a/src/services/handleStatusError.js
+++ b/src/services/handleStatusError.js
@@ -6,7 +6,7 @@ import Ora from "ora";
  *
  * @param {int} status the status code
  */
-export const handleStatusError = (status) => {
+export const handleStatusError = (status, err) => {
   const spinner = Ora();
   switch (status) {
     case 404:
@@ -19,6 +19,7 @@ export const handleStatusError = (status) => {
       break;
     case 500:
       spinner.fail("Server Side Error.", err);
+	  console.log(err);
       process.exit();
       break;
   }


### PR DESCRIPTION
The `handleStatusError()` function doesn't take in the parameter for the exception itself, which is called "err".

However, the function attempts to use "err" later on despite it not existing, causing a `ReferenceException`. This prevents the application from displaying the real error and instead shows that exception.

Additionally, the `spinner.fail()` call does not display enough information to the user. I added a `console.log()` so that the full exception is output.

This fixes #8.