### PR TITLE
Remove PAT scope reference for GHES

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You will need to generate a Personal Access Token (PAT) within your source (Azur
 
 * For Azure DevOps: `read` for `Code`.
 * For GitHub Cloud: `repo`.  
-* For GitHub Server (3.4+): `repo`
+
 ## Dependencies
 
 Use the command ```cd <pathname of migration analyzer directory> && npm install``` to change to your ```migration-analyzer``` directory.  This will install the following project dependencies:


### PR DESCRIPTION
Fixes https://github.com/github/gh-migration-analyzer/issues/15. 

This PR removes the reference to GHES in the PAT scoping documentation, since this tool is focused on GitHub Cloud and ADO Cloud. The extra mention of GHES adds confusion. 