### PR TITLE
Export more repository metrics (discussions, releases, packages, size)

### DIFF
--- a/src/api/gitHub.js
+++ b/src/api/gitHub.js
@@ -74,6 +74,9 @@ export const fetchRepoInOrg = async (org, token, server, cursor) => {
                 pullRequests(first: 1) {
                   totalCount
                 }
+                discussions(first: 1) {
+                  totalCount
+                }
                 name
                 id
                 url
@@ -186,6 +189,7 @@ export const fetchRepoMetrics = async (repositories) => {
       numOfPullRequests: repo.node.pullRequests.totalCount,
       numOfIssues: repo.node.issues.totalCount,
       numOfProjects: repo.node.projects.totalCount,
+      numOfDiscussions: repo.node.discussions.totalCount,
       wikiEnabled: repo.node.hasWikiEnabled,
     };
     if (repo.node.pullRequests.totalCount > orgMetrics.mostPr) {
@@ -243,6 +247,7 @@ export const storeRepoMetrics = async (organization) => {
     { id: "numOfPullRequests", title: "Number Of Pull Requests" },
     { id: "numOfIssues", title: "Number of Issues" },
     { id: "numOfProjects", title: "Number of Projects" },
+    { id: "numOfDiscussions", title: "Number of Discussions" },
     { id: "wikiEnabled", title: "Wiki Enabled" },
   ];
 

--- a/src/api/gitHub.js
+++ b/src/api/gitHub.js
@@ -87,6 +87,7 @@ export const fetchRepoInOrg = async (org, token, server, cursor) => {
                 id
                 url
                 isPrivate
+                diskUsage
               }
             }
           }
@@ -199,6 +200,7 @@ export const fetchRepoMetrics = async (repositories) => {
       numOfPackages: repo.node.packages.totalCount,
       numOfReleases: repo.node.releases.totalCount,
       wikiEnabled: repo.node.hasWikiEnabled,
+      diskUsage: repo.node.diskUsage,
     };
     if (repo.node.pullRequests.totalCount > orgMetrics.mostPr) {
       orgMetrics.mostPr = repo.node.pullRequests.totalCount;
@@ -259,6 +261,7 @@ export const storeRepoMetrics = async (organization) => {
     { id: "numOfPackages", title: "Number of Packages" },
     { id: "numOfReleases", title: "Number of Releases" },
     { id: "wikiEnabled", title: "Wiki Enabled" },
+    { id: "diskUsage", title: "Size (KiB)" },
   ];
 
   console.log();

--- a/src/api/gitHub.js
+++ b/src/api/gitHub.js
@@ -77,6 +77,9 @@ export const fetchRepoInOrg = async (org, token, server, cursor) => {
                 discussions(first: 1) {
                   totalCount
                 }
+                packages(first: 1) {
+                  totalCount
+                }
                 name
                 id
                 url
@@ -190,6 +193,7 @@ export const fetchRepoMetrics = async (repositories) => {
       numOfIssues: repo.node.issues.totalCount,
       numOfProjects: repo.node.projects.totalCount,
       numOfDiscussions: repo.node.discussions.totalCount,
+      numOfPackages: repo.node.packages.totalCount,
       wikiEnabled: repo.node.hasWikiEnabled,
     };
     if (repo.node.pullRequests.totalCount > orgMetrics.mostPr) {
@@ -248,6 +252,7 @@ export const storeRepoMetrics = async (organization) => {
     { id: "numOfIssues", title: "Number of Issues" },
     { id: "numOfProjects", title: "Number of Projects" },
     { id: "numOfDiscussions", title: "Number of Discussions" },
+    { id: "numOfPackages", title: "Number of Packages" },
     { id: "wikiEnabled", title: "Wiki Enabled" },
   ];
 

--- a/src/api/gitHub.js
+++ b/src/api/gitHub.js
@@ -80,6 +80,9 @@ export const fetchRepoInOrg = async (org, token, server, cursor) => {
                 packages(first: 1) {
                   totalCount
                 }
+                releases(first: 1) {
+                  totalCount
+                }
                 name
                 id
                 url
@@ -194,6 +197,7 @@ export const fetchRepoMetrics = async (repositories) => {
       numOfProjects: repo.node.projects.totalCount,
       numOfDiscussions: repo.node.discussions.totalCount,
       numOfPackages: repo.node.packages.totalCount,
+      numOfReleases: repo.node.releases.totalCount,
       wikiEnabled: repo.node.hasWikiEnabled,
     };
     if (repo.node.pullRequests.totalCount > orgMetrics.mostPr) {
@@ -253,6 +257,7 @@ export const storeRepoMetrics = async (organization) => {
     { id: "numOfProjects", title: "Number of Projects" },
     { id: "numOfDiscussions", title: "Number of Discussions" },
     { id: "numOfPackages", title: "Number of Packages" },
+    { id: "numOfReleases", title: "Number of Releases" },
     { id: "wikiEnabled", title: "Wiki Enabled" },
   ];
 


### PR DESCRIPTION
I think this PR will be a valuable addition to gh-migration-analyzer, as the `diskUsage` (named "Size") property can be a problem/blocker for migrations in the case of very large repositories.

Same with releases -- they count against a repository's metadata limit, so a repository with many release (assets) or enough large release assets will fail to migrate. A future addition to this would be to sum up the size of all release assets, as this will be a more direct indicator of migration problems.

I also included the number of Discussions and number of Packages, because these properties are not migrated by GEI, so it would be nice to see at a glance which repositories will not fully migrate with GEI.