### PR TITLE
Add option to use agent in node fetch options

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Options:
   -o, --organization <organization> GitHub organization name (required)
   -t, --token <PAT> GitHub personal access token
   -s, --server <GRAPHQL URL> GraphQL endpoint for a GHES instance. 
+  -a, --allow-untrusted-ssl-certificates Allow connections to a GitHub API endpoint that presents a SSL certificate that isn't issued by a trusted CA"
   -h, --help Help command for GitHub options
 
 ````

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Options:
   -o, --organization <organization> GitHub organization name (required)
   -t, --token <PAT> GitHub personal access token
   -s, --server <GRAPHQL URL> GraphQL endpoint for a GHES instance. 
-  -a, --allow-untrusted-ssl-certificates Allow connections to a GitHub API endpoint that presents a SSL certificate that isn't issued by a trusted CA"
+  -a, --allow-untrusted-ssl-certificates Allow connections to a GitHub API endpoint that presents a SSL certificate that isn't issued by a trusted CA
   -h, --help Help command for GitHub options
 
 ````

--- a/src/api/gitHub.js
+++ b/src/api/gitHub.js
@@ -43,7 +43,7 @@ const orgMetrics = {
  * @param {string} org the organization
  * @param {string} token the token
  * @param {string} server the graphql endpoint for a GHES instance
- * @param {boolean} allowUntrustedSslCertificates the allow connections to a GitHub API endpoint that presents a SSL certificate that isn't issued by a trusted CA option
+ * @param {boolean} allowUntrustedSslCertificate allow connections to a GitHub API endpoint that presents a SSL certificate that isn't issued by a trusted CA
  * @param {string} cursor the last repository fetched
  * @returns {[Objects]} the fetched repo information
  */
@@ -67,7 +67,7 @@ export const fetchRepoInOrg = async (org, token, server, allowUntrustedSslCertif
  * @returns {object} the fetched org information
  */
 export const fetchOrgInfo = async (org, server, token, allowUntrustedSslCertificates) => {
-  return await fetch(determineGraphQLEndpoint(server), fetchOrgInfoOptions(org,token,allowUntrustedSslCertificates))
+  return await fetch(determineGraphQLEndpoint(server), fetchOrgInfoOptions(org, token, allowUntrustedSslCertificates))
     .then((res) => {
       handleStatusError(res.status);
       return res.json();

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,7 @@ program
   .option("-o, --organization <organization>", "Organization Name")
   .option("-t, --token <PAT>", "Personal Access Token")
   .option("-s, --server <GRAPHQL URL>", "GHES GraphQL Endpoint")
+  .option("-a, --allow-untrusted-ssl-certificates", "Allow connections to a GitHub API endpoint that presents a SSL certificate that isn't issued by a trusted CA")
   .alias("a")
   .description("Fetch GitHub Organization Metrics")
   .action(async (options) =>


### PR DESCRIPTION
Adding a ```-ssc ``` option that allows a GHES instance using a self-signed certificate to be targeted by the migration analyzer. resolves https://github.com/github/gh-migration-analyzer/issues/18